### PR TITLE
fixed get_latest_revision() method in ModelsChecker

### DIFF
--- a/yangvalidator/v2/modelsChecker.py
+++ b/yangvalidator/v2/modelsChecker.py
@@ -93,7 +93,15 @@ class ModelsChecker:
                     else:
                         raise
 
-            ret.append('{}@{}.yang'.format(module_name, revisions[revisions_to_sort.index(max(revisions_to_sort))]))
+            try:
+                ret.append(
+                    '{}@{}.yang'.format(
+                        module_name,
+                        revisions[revisions_to_sort.index(max(revisions_to_sort, default=0))]
+                    )
+                )
+            except ValueError:
+                pass
         return ret
 
     def revision(self, path: str) -> str:


### PR DESCRIPTION
fixed passing an empty sequence to max() function in get_latest_revision() method in ModelsChecker